### PR TITLE
Fixed Loader Bug

### DIFF
--- a/Parts/Weapons/CRAM megacannon/Loader/loader3d.rules
+++ b/Parts/Weapons/CRAM megacannon/Loader/loader3d.rules
@@ -206,7 +206,7 @@ Part : <./Data/ships/terran/base_part_terran.rules>/Part
 			Type = MultiToggle
 			Toggles
 			[
-				{Toggle = CRAM_LOADER_AmmoStorageToggleRight, invert = true}//if ammo storage is not full.
+				// {Toggle = CRAM_LOADER_AmmoStorageToggleRight, invert = true}//if ammo storage is not full.
 			]
 			Mode = All
 		}
@@ -215,7 +215,7 @@ Part : <./Data/ships/terran/base_part_terran.rules>/Part
 			Type = MultiToggle
 			Toggles
 			[
-				{Toggle = CRAM_LOADER_AmmoStorageToggleLeft, invert = true}//if ammo storage is not full.
+				// {Toggle = CRAM_LOADER_AmmoStorageToggleLeft, invert = true}//if ammo storage is not full.
 			]
 			Mode = All
 		}

--- a/Parts/Weapons/CRAM megacannon/Loader/loader3x.rules
+++ b/Parts/Weapons/CRAM megacannon/Loader/loader3x.rules
@@ -177,7 +177,7 @@ Part : <./Data/ships/terran/base_part_terran.rules>/Part
 			Type = MultiToggle
 			Toggles
 			[
-				{Toggle = CRAM_LOADER_AmmoStorageToggle, invert = true}//if ammo storage is not full.
+				// {Toggle = CRAM_LOADER_AmmoStorageToggle, invert = true}//if ammo storage is not full.
 			]
 			Mode = All
 		}


### PR DESCRIPTION
Fixed bug where loaders didn't load packers when the cram cannon is full.

### Changes made:
- Changed HaltConverter to take in no toggles, in turn always having it on.
